### PR TITLE
Accept token signer for Xbox login

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,12 +3,12 @@ module github.com/df-mc/go-playfab/v2
 go 1.26.1
 
 require (
-	github.com/df-mc/go-xsapi/v2 v2.0.0
+	github.com/df-mc/go-xsapi/v2 v2.0.2-0.20260618232321-7db98a0b7856
 	golang.org/x/text v0.35.0
 )
 
 require (
 	github.com/coder/websocket v1.8.14 // indirect
-	github.com/go-jose/go-jose/v4 v4.1.3 // indirect
+	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -1,9 +1,9 @@
 github.com/coder/websocket v1.8.14 h1:9L0p0iKiNOibykf283eHkKUHHrpG7f65OE3BhhO7v9g=
 github.com/coder/websocket v1.8.14/go.mod h1:NX3SzP+inril6yawo5CQXx8+fk145lPDC6pumgx0mVg=
-github.com/df-mc/go-xsapi/v2 v2.0.0 h1:StZ7j0WmXdlLqjLaJFYxJI11eAygepasGoVt5wSnk40=
-github.com/df-mc/go-xsapi/v2 v2.0.0/go.mod h1:bNmYtmtqm85vp44R0ZEnly4u+as58sbr5KV1rLwkfjg=
-github.com/go-jose/go-jose/v4 v4.1.3 h1:CVLmWDhDVRa6Mi/IgCgaopNosCaHz7zrMeF9MlZRkrs=
-github.com/go-jose/go-jose/v4 v4.1.3/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
+github.com/df-mc/go-xsapi/v2 v2.0.2-0.20260618232321-7db98a0b7856 h1:6tmfs866ngZ8R6jFlDfXzBP9N+vmlkX4IlM1+0lVxlI=
+github.com/df-mc/go-xsapi/v2 v2.0.2-0.20260618232321-7db98a0b7856/go.mod h1:Gi/zQG2DFMJOMt4DIjuBuINTnU4YnZINe+RyFyza8oo=
+github.com/go-jose/go-jose/v4 v4.1.4 h1:moDMcTHmvE6Groj34emNPLs/qtYXRVcd6S7NHbHz3kA=
+github.com/go-jose/go-jose/v4 v4.1.4/go.mod h1:x4oUasVrzR7071A4TnHLGSPpNOm2a21K9Kf04k1rs08=
 github.com/google/uuid v1.6.0 h1:NIvaJDMOsjHA8n1jAhLSgzrAzy1Hgr+hNrb57e+94F0=
 github.com/google/uuid v1.6.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=

--- a/xbox.go
+++ b/xbox.go
@@ -10,15 +10,16 @@ import (
 )
 
 // LoginWithXbox logs in to PlayFab account in the specified title ID with an Xbox Live account.
-func LoginWithXbox(ctx context.Context, t title.Title, client *xsapi.Client, config ClientConfig) (*Client, error) {
+func LoginWithXbox(ctx context.Context, t title.Title, client xsapi.TokenAndSignaturer, config ClientConfig) (*Client, error) {
 	return Login(ctx, t, &XBLIdentityProvider{Client: client}, config)
 }
 
 // XBLIdentityProvider implements an [IdentityProvider] that logs in to PlayFab account
-// with an Xbox Live account using the underlying Client.
+// with an Xbox Live account using the underlying token and signature resolver.
 type XBLIdentityProvider struct {
-	// Client is the Xbox Live API Client used to log in to Xbox Live services.
-	Client *xsapi.Client
+	// Client resolves the XSTS token and signature policy used to log in to
+	// PlayFab with Xbox Live.
+	Client xsapi.TokenAndSignaturer
 }
 
 // Login ...


### PR DESCRIPTION
## Summary
- change `LoginWithXbox` to accept `xsapi.TokenAndSignaturer` instead of requiring `*xsapi.Client`
- update `XBLIdentityProvider.Client` to the same narrow interface while keeping the field name source-compatible
- bump `go-xsapi` to the merged version that exposes the interface

## Testing
- `gofmt -w xbox.go`
- `go mod tidy`
- `go test ./...`
- `go vet ./...`
- `git diff --check`
